### PR TITLE
Add slide-aware video summarization

### DIFF
--- a/README.md
+++ b/README.md
@@ -633,11 +633,14 @@ This project is licensed under the MIT License.
 ## 🎬 영상 요약 스크립트 사용법
 
 1. Google Drive 공유 링크 또는 로컬 비디오 경로를 준비합니다.
-2. 의존성 설치 후 다음 명령어로 실행합니다.
+2. 필요한 경우 발표 자료(PDF)나 별도 스크립트(txt)를 함께 준비합니다.
+3. 의존성 설치 후 다음 명령어로 실행합니다.
    ```bash
-   python scripts/video_summary.py <영상 경로 또는 구글 드라이브 링크>
+   python scripts/video_summary.py <영상 경로 또는 구글 드라이브 링크> \
+       --slides <슬라이드 PDF 경로> --script <텍스트 스크립트 경로>
    ```
-3. `downloads/summary.md` 파일로 요약 결과가 저장되며, 해당 파일 경로 링크를 공유할 수 있습니다.
+   슬라이드나 스크립트가 없으면 옵션을 생략하면 됩니다.
+4. `downloads/summary.md`에 요약, 전체 스크립트, OCR 추출 내용, 주요 캡처 이미지가 포함된 보고서가 생성됩니다.
 
 
 ## 📝 라이센스

--- a/scripts/video_summary.py
+++ b/scripts/video_summary.py
@@ -41,7 +41,16 @@ def transcribe_audio(audio_path: str, model_name: str = "base") -> str:
 
 
 def extract_text_from_video(video_path: str, interval: int = 1) -> List[str]:
-    """Extract on-screen text every `interval` seconds using OCR."""
+    """
+    비디오에서 일정 간격마다 화면의 텍스트를 OCR로 추출합니다.
+    
+    Args:
+        video_path: 처리할 비디오 파일 경로.
+        interval: 텍스트 추출 간격(초)입니다.
+    
+    Returns:
+        추출된 화면 텍스트 문자열의 리스트를 반환합니다.
+    """
     texts = []
     cap = cv2.VideoCapture(video_path)
     fps = cap.get(cv2.CAP_PROP_FPS) or 30
@@ -60,7 +69,19 @@ def extract_text_from_video(video_path: str, interval: int = 1) -> List[str]:
 
 
 def summarize_text(text: str, supplement: str = "", max_length: int = 200) -> str:
-    """Summarize text with OpenAI GPT model, using supplemental material."""
+    """
+    OpenAI GPT 모델을 사용하여 주어진 텍스트와 참고 자료를 한국어로 요약합니다.
+    
+    텍스트와 선택적으로 제공된 참고 자료를 결합하여, 지정된 최대 길이 이내로 핵심 내용을 요약합니다. OpenAI API 키가 환경 변수에 설정되어 있어야 하며, 설정되지 않은 경우 예외가 발생합니다.
+    
+    Args:
+        text: 요약할 주요 텍스트(예: 영상 스크립트).
+        supplement: 요약에 참고할 추가 자료(예: 슬라이드, 스크립트 등). 기본값은 빈 문자열입니다.
+        max_length: 요약문의 최대 문자 수. 기본값은 200입니다.
+    
+    Returns:
+        요약된 한국어 텍스트 문자열.
+    """
     openai.api_key = os.getenv('OPENAI_API_KEY')
     if not openai.api_key:
         raise RuntimeError('OPENAI_API_KEY not set')
@@ -77,7 +98,22 @@ def summarize_text(text: str, supplement: str = "", max_length: int = 200) -> st
 
 
 def create_markdown(summary: str, transcript: str, ocr_texts: List[str], frames: List[str], supplement: str, path: str) -> str:
-    """Write summary, transcript and optional materials to markdown file."""
+    """
+    요약, 스크립트, OCR 텍스트, 참고 자료, 캡처 이미지를 포함한 마크다운 파일을 생성합니다.
+    
+    summary, transcript, supplement, OCR로 추출된 텍스트, 캡처된 프레임 이미지를 지정된 경로의 마크다운 파일로 저장합니다.
+    
+    Args:
+        summary: 비디오 및 보조 자료의 요약문.
+        transcript: 음성 인식으로 추출된 전체 스크립트.
+        ocr_texts: 비디오 프레임에서 OCR로 추출된 텍스트 목록.
+        frames: 저장된 주요 캡처 이미지 파일 경로 목록.
+        supplement: PDF 슬라이드 또는 스크립트 등 추가 참고 자료의 텍스트.
+        path: 생성할 마크다운 파일의 경로.
+    
+    Returns:
+        생성된 마크다운 파일의 경로.
+    """
     with open(path, "w", encoding="utf-8") as f:
         f.write("# Video Summary\n\n")
         f.write("## 요약\n")
@@ -105,7 +141,15 @@ def create_markdown(summary: str, transcript: str, ocr_texts: List[str], frames:
 
 
 def read_slides(slides_path: str) -> str:
-    """Extract text from pdf slides."""
+    """
+    PDF 슬라이드 파일에서 모든 페이지의 텍스트를 추출하여 하나의 문자열로 반환합니다.
+    
+    Args:
+        slides_path: 텍스트를 추출할 PDF 파일 경로.
+    
+    Returns:
+        PDF의 모든 페이지에서 추출한 텍스트를 개행 문자로 연결한 문자열.
+    """
     texts = []
     with pdfplumber.open(slides_path) as pdf:
         for page in pdf.pages:
@@ -116,12 +160,31 @@ def read_slides(slides_path: str) -> str:
 
 
 def read_script(script_path: str) -> str:
+    """
+    텍스트 스크립트 파일의 전체 내용을 읽어 반환합니다.
+    
+    Args:
+        script_path: 읽을 텍스트 파일의 경로.
+    
+    Returns:
+        파일의 전체 텍스트 내용.
+    """
     with open(script_path, "r", encoding="utf-8") as f:
         return f.read()
 
 
 def capture_frames(video_path: str, output_dir: str = "downloads/frames", interval: int = 10) -> List[str]:
-    """Capture frames every `interval` seconds and return image paths."""
+    """
+    비디오 파일에서 지정된 간격(초)마다 프레임을 캡처하여 이미지 파일로 저장하고, 저장된 이미지 경로 목록을 반환합니다.
+    
+    Args:
+        video_path: 프레임을 추출할 비디오 파일 경로.
+        output_dir: 캡처된 프레임 이미지를 저장할 디렉터리 경로. 기본값은 "downloads/frames"입니다.
+        interval: 프레임을 캡처할 시간 간격(초). 기본값은 10초입니다.
+    
+    Returns:
+        저장된 프레임 이미지 파일의 경로 리스트.
+    """
     os.makedirs(output_dir, exist_ok=True)
     frames = []
     cap = cv2.VideoCapture(video_path)
@@ -143,7 +206,20 @@ def capture_frames(video_path: str, output_dir: str = "downloads/frames", interv
 
 
 def process_video(source: str, model_name: str = 'base', slides: Optional[str] = None, script: Optional[str] = None) -> str:
-    """Full pipeline from source to markdown summary."""
+    """
+    비디오 파일 또는 Google Drive 링크에서 오디오, 자막, OCR 텍스트, 보조 자료(슬라이드, 스크립트)를 추출하여 요약 마크다운 파일을 생성합니다.
+    
+    비디오 다운로드, 오디오 추출, 음성 인식, 화면 텍스트 추출, 프레임 캡처, 보조 자료 통합, 요약 생성, 마크다운 파일 저장까지 전체 파이프라인을 실행합니다.
+    
+    Args:
+        source: 비디오 파일 경로 또는 Google Drive 링크.
+        model_name: Whisper 음성 인식 모델 이름(기본값: 'base').
+        slides: PDF 슬라이드 파일 경로(선택).
+        script: 텍스트 스크립트 파일 경로(선택).
+    
+    Returns:
+        생성된 마크다운 요약 파일의 경로.
+    """
     video_path = download_video(source)
     audio_path = os.path.join('downloads', 'audio.wav')
     extract_audio(video_path, audio_path)


### PR DESCRIPTION
## Summary
- extend `video_summary.py` to accept slide PDFs and text scripts
- generate key frame captures and include them in markdown reports
- allow providing supplemental materials to improve summarization
- update README usage instructions for the new options

## Testing
- `python test/run_all_tests.py` *(fails: ModuleNotFoundError: fastapi, requests, dotenv)*

------
https://chatgpt.com/codex/tasks/task_e_68499c36909c832992fd0a709265c3a3